### PR TITLE
Forums UI: Show latest comments at the top of thread view

### DIFF
--- a/src/frontend/src/Pages/mainPages/Forums.tsx
+++ b/src/frontend/src/Pages/mainPages/Forums.tsx
@@ -185,7 +185,7 @@ const Forums: React.FC = () => {
             </div>
 
             <div style={{ marginTop: "2rem" }}>
-              {comments.map((c, idx) => (
+              {[...comments].reverse().map((c, idx) => (
                 <div key={idx} style={{
                   display: "flex",
                   alignItems: "flex-start",


### PR DESCRIPTION
- Updated comment rendering in the forum modal to reverse the order, displaying the newest comments first.
- Preserves comment state immutability by using a reversed copy of the array.
- Improves UX by surfacing recent activity without scrolling.

L=ENG-FEED
TEST=manual
- Opened multiple forums and verified latest comments appear at the top
- Confirmed new comment appears immediately without reload